### PR TITLE
Fire a Perl callback on probe trigger

### DIFF
--- a/lib/Devel/Probe.pm
+++ b/lib/Devel/Probe.pm
@@ -44,6 +44,11 @@ Version 0.000001
     use Devel::Probe (check => 1);
     ...
 
+    Devel::Probe::trigger(sub {
+        my ($file, $line) = @_;
+        # probe logic
+    });
+
 =head1 DESCRIPTION
 
 Use this module to allow the possibility of creating probes for some lines in
@@ -87,13 +92,35 @@ Add a probe for the given file in each of the given lines.
 
 =back
 
+=head1 EXAMPLE
+
+This will invoke the C<trigger> callback whenever line 14 executes, and use
+C<PadWalker> to dump the local variables.
+
+    # in my_cool_script.pl
+    use Data::Dumper qw(Dumper);
+    use PadWalker qw(peek_my);
+    use Devel::Probe (check => 1);
+
+    Devel::Probe::trigger(sub {
+        my ($file, $line) = @_;
+        say Dumper(peek_my(1)); # 1 to jump up one level in the stack;
+    });
+
+    my $count;
+    while (1) {
+        $count++;
+        my $something_inside_the_loop = $count * 2;
+        sleep 5;
+    }
+
+    # /tmp/devel-probe-config.cfg
+    enable
+    probe my_cool_script.pl 13
+
 =head1 TODO
 
 =over 4
-
-=item
-
-For now, a probe will simply print a line to C<stderr>.
 
 =item
 


### PR DESCRIPTION
Please excuse baby's first XS.

This adds a setter to bind a callback to probe trigger. That callback can then do whatever makes sense -- invoke PadWalker, shove things into a Sereal payload and dump to disk, etc. 

### Some testing notes / TODOs

#### SIGHUP as control
Gently bumped into an issue here testing with a Mojolicious app; Mojo's webservers use SIGHUP themselves.

#### Validating that the probe is a coderef
A very immediate improvement to this patch would be validating that the argument to `Devel::Probe::trigger` is a string or coderef, and not something else. Perl will just bark and say "Not a CODE reference" if its wrong, but the line number for that message will be all wrong -- it will be the line of the probe, not the code location where the probe is defined.

#### Exceptions in the probe
An exception in your probe is very difficult to cope with. It means that literally any line of code might toss an exception. Not sure what to do with this beyond perhaps wrapping the probe in an `eval` regardless of what the user does; it reminds a bit of [the motivation Java had for removing `Thread.stop`](https://docs.oracle.com/javase/6/docs/technotes/guides/concurrency/threadPrimitiveDeprecation.html).

#### Figuring out the file path
While testing with Mojo, my application file path was absolute, which I was not expecting. As a result, my probes did not work initially. In a large application it can be tricky to understand how to name files in the `cfg` file.

#### "Infecting" modules down the stack?
From some intrepid `fprintf` debugging, it looks like `Devel::Probe` only witnesses files in modules directly loaded in the same file as `Devel::Probe` itself. This means you cannot place probes on things deeper in the stack. Not sure how to tackle this. I suppose there's a careful balance to be found here between controlling exposure/perf overhead and the debugging power to probe anything at any level.