### PR TITLE
Test for install/reinstall.

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -7,6 +7,7 @@ t/000-use.t
 t/004-status-installed.t
 t/005-status-enabled.t
 t/007-trigger.t
+t/008-trigger-after-reinstall.t
 
 Changes
 LICENSE

--- a/t/008-trigger-after-reinstall.t
+++ b/t/008-trigger-after-reinstall.t
@@ -1,0 +1,44 @@
+use strict;
+use warnings;
+use Test::More;
+use Devel::Probe;
+my %probes = (
+    fire_before_reinstall => [ 28, 29 ],
+    skip_because_uninstalled => [ 31 ],
+    fire_after_reinstall => [ 35, 36 ],
+);
+
+my @triggered;
+sub probe {
+    my ($file, $line) = @_;
+    push @triggered, $line;
+}
+
+Devel::Probe::trigger(\&probe);
+
+my $actions = [
+    { action => "enable" },
+    { action => "define", "file" => __FILE__, lines => $probes{fire_before_reinstall} },
+    { action => "define", "file" => __FILE__, lines => $probes{skip_beacuse_uninstalled} },
+    { action => "define", "file" => __FILE__, lines => $probes{fire_after_reinstall} },
+];
+
+Devel::Probe::config({actions => $actions});
+
+my $x = 1; # probe 1
+my $y = 2; # probe 2
+Devel::Probe::remove();
+my $z = $x + $y; # probe defined, but not fired -- Devel::Probe not active
+Devel::Probe::install();
+Devel::Probe::trigger(\&probe);
+Devel::Probe::config({actions => $actions});
+my $bar = $z * 42; # probe 3. should fire, but might not if we can't gracefully re-install
+my $baz = $bar * 11; # probe 4. should fire, but might not if we can't gracefully re-install
+
+is_deeply(
+    \@triggered,
+    [ @{$probes{fire_before_reinstall}}, @{$probes{fire_after_reinstall}} ],
+    "exactly expected probes fired"
+);
+
+done_testing;


### PR DESCRIPTION
Runtime enable/disable keeps overhead low when probing is not being
used: Devel::Probe in disabled state introduced an additional ~500
micros mean, and ~1-2ms at p99.

However, in a perfect world we'd totally unhook the OP_NEXTSTATE when
probing was not being used. This would reduce the overhead to 0.

This test checks for our ability to dynamically install/remove/install
during the process lifetime and have the expected probes fire.