### PR TITLE
btyler/dump-in-perl

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,10 +9,10 @@ WriteMakefile(
     MIN_PERL_VERSION => 5.018000,
     PREREQ_PM      => {
         'XSLoader'     => 0,
+        'Storable'     => 0
     },
     TEST_REQUIRES  => {
         'Test::More'   => 0,
-        'Test::Output' => 0,
         'Devel::Leak' => 0,
     },
     AUTHOR         => [

--- a/lib/Devel/Probe.pm
+++ b/lib/Devel/Probe.pm
@@ -2,6 +2,7 @@ package Devel::Probe;
 use strict;
 use warnings;
 
+use Storable qw(dclone);
 use XSLoader;
 
 our $VERSION = '0.000004';
@@ -35,10 +36,6 @@ sub config {
             Devel::Probe::disable();
             next;
         }
-        if ($action->{action} eq 'dump') {
-            Devel::Probe::dump();
-            next;
-        }
         if ($action->{action} eq 'clear') {
             Devel::Probe::clear();
             next;
@@ -55,6 +52,10 @@ sub config {
             next;
         }
     }
+}
+
+sub dump {
+    return dclone(Devel::Probe::_internal_probe_state());
 }
 
 1;

--- a/probe.xs
+++ b/probe.xs
@@ -152,61 +152,6 @@ static OP* probe_nextstate(pTHX)
     return ret;
 }
 
-static void probe_dump(void)
-{
-    hv_iterinit(probe_hash);
-    while (1) {
-        SV* key = 0;
-        SV* value = 0;
-        char* kstr = 0;
-        STRLEN klen = 0;
-        HV* lines = 0;
-        HE* entry = hv_iternext(probe_hash);
-        if (!entry) {
-            break; /* no more hash keys */
-        }
-        key = hv_iterkeysv(entry);
-        if (!key) {
-            continue; /* invalid key */
-        }
-        kstr = SvPV(key, klen);
-        if (!kstr) {
-            continue; /* invalid key */
-        }
-        fprintf(stderr, "PROBE dump file [%s]\n", kstr);
-
-        value = hv_iterval(probe_hash, entry);
-        if (!value) {
-            continue; /* invalid value */
-        }
-        lines = (HV*) SvRV(value);
-        hv_iterinit(lines);
-        while (1) {
-            SV* key = 0;
-            SV* value = 0;
-            char* kstr = 0;
-            STRLEN klen = 0;
-            HE* entry = hv_iternext(lines);
-            if (!entry) {
-                break; /* no more hash keys */
-            }
-            key = hv_iterkeysv(entry);
-            if (!key) {
-                continue; /* invalid key */
-            }
-            kstr = SvPV(key, klen);
-            if (!kstr) {
-                continue; /* invalid key */
-            }
-            value = hv_iterval(lines, entry);
-            if (!value || !SvTRUE(value)) {
-                continue;
-            }
-            fprintf(stderr, "PROBE dump line [%s]\n", kstr);
-        }
-    }
-}
-
 static void probe_enable(void)
 {
     if (probe_is_enabled()) {
@@ -322,10 +267,11 @@ CODE:
     probe_disable();
     probe_clear();
 
-void
-dump()
+HV *
+_internal_probe_state()
 CODE:
-    probe_dump();
+    RETVAL = probe_hash;
+OUTPUT: RETVAL
 
 void
 add_probe(const char* file, int line, int type)

--- a/t/006-dump.t
+++ b/t/006-dump.t
@@ -8,21 +8,21 @@ use Devel::Probe;
 my $config = {
     actions => [
         { action => 'define', file => "foo", lines => [qw(4 5 6)] },
-        { action => 'define', file => "bar", lines => [qw(7 8 9)], type => "permanent" },
+        { action => 'define', file => "bar", lines => [qw(7 8 9)], type => Devel::Probe::PERMANENT },
     ],
 };
 Devel::Probe::config($config);
 is_deeply(Devel::Probe::dump(), 
     { 
         foo => {
-            4 => 1,
-            5 => 1,
-            6 => 1,
+            4 => Devel::Probe::ONCE,
+            5 => Devel::Probe::ONCE,
+            6 => Devel::Probe::ONCE,
         },
         bar => {
-            7 => 2,
-            8 => 2,
-            9 => 2,
+            7 => Devel::Probe::PERMANENT,
+            8 => Devel::Probe::PERMANENT,
+            9 => Devel::Probe::PERMANENT,
         },
     },
 "dump returned a hash representing the probes in the correct state");

--- a/t/006-dump.t
+++ b/t/006-dump.t
@@ -1,0 +1,30 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+use Devel::Probe;
+
+my $config = {
+    actions => [
+        { action => 'define', file => "foo", lines => [qw(4 5 6)] },
+        { action => 'define', file => "bar", lines => [qw(7 8 9)], type => "permanent" },
+    ],
+};
+Devel::Probe::config($config);
+is_deeply(Devel::Probe::dump(), 
+    { 
+        foo => {
+            4 => 1,
+            5 => 1,
+            6 => 1,
+        },
+        bar => {
+            7 => 2,
+            8 => 2,
+            9 => 2,
+        },
+    },
+"dump returned a hash representing the probes in the correct state");
+
+done_testing;

--- a/t/007-trigger.t
+++ b/t/007-trigger.t
@@ -2,16 +2,15 @@ use strict;
 use warnings;
 
 use Test::More;
-use Test::Output;
 
 use Devel::Probe;
 
 my @triggered;
 my $trigger_file = 't/007-trigger.t'; # this file
 my %trigger_lines = (
-    default   => [qw/ 23 /], # probe 1
-    once      => [qw/ 24 /], # probe 2
-    permanent => [qw/ 25 /], # probe 3
+    default   => [qw/ 22 /], # probe 1
+    once      => [qw/ 23 /], # probe 2
+    permanent => [qw/ 24 /], # probe 3
 );
 
 exit main();
@@ -62,18 +61,10 @@ sub config {
             { action => 'disable' },
             { action => 'clear' },
             @defines,
-            { action => 'dump' },
             { action => 'enable' },
         ],
     );
-    my $stderr = stderr_from {
-        Devel::Probe::config(\%config);
-    };
-    foreach my $type (keys %trigger_lines) {
-        foreach my $line (@{ $trigger_lines{$type} }) {
-            like($stderr, qr/dump line \[$line\]/, "probe dump contains line $line, type $type");
-        }
-    }
+    Devel::Probe::config(\%config);
 }
 
 sub clear {

--- a/t/007-trigger.t
+++ b/t/007-trigger.t
@@ -9,8 +9,8 @@ my @triggered;
 my $trigger_file = 't/007-trigger.t'; # this file
 my %trigger_lines = (
     default   => [qw/ 22 /], # probe 1
-    once      => [qw/ 23 /], # probe 2
-    permanent => [qw/ 24 /], # probe 3
+    Devel::Probe::ONCE      ,=> [qw/ 23 /], # probe 2
+    Devel::Probe::PERMANENT ,=> [qw/ 24 /], # probe 3
 );
 
 exit main();
@@ -28,7 +28,7 @@ sub run {
     my @expected;
     if ($run != 0 && $run != 4) {
         foreach my $type (keys %trigger_lines) {
-            if (($run == 1) || ($run > 1 && $type eq 'permanent')) {
+            if (($run == 1) || ($run > 1 && $type eq Devel::Probe::PERMANENT)) {
                 push @expected, map { [ $trigger_file, $_ ] } @{ $trigger_lines{$type} };
             }
         }

--- a/t/009-memleak.t
+++ b/t/009-memleak.t
@@ -4,9 +4,7 @@ use Test::More;
 use Devel::Probe;
 use Devel::Leak;
 
-use constant ONCE => 1;
-
-my @probe = (__FILE__, 40, ONCE);
+my @probe = (__FILE__, 40, Devel::Probe::ONCE);
 sub probe_cb { }
 
 leak_test(sub {


### PR DESCRIPTION
Minor couple of patches to shift some non-perf-sensitive code to Perl. Along the way probe types changed to constants and gained a touch of validation.

This might be exposing internal state a little too transparently. However, I think it's reasonable to give people a machine-consumable picture of the probes, so I think if we do change the internal probe representation it would still make sense to have this method and do some translation from internal to external.