### PR TITLE
btyler/add-probe-in-perl

### DIFF
--- a/lib/Devel/Probe.pm
+++ b/lib/Devel/Probe.pm
@@ -44,15 +44,21 @@ sub config {
             next unless $file;
 
             my $type = $action->{type} // ONCE;
-            if ($type ne ONCE && $type ne PERMANENT) {
-                croak sprintf("'%s' is not a valid probe type: try Devel::Probe::ONCE|PERMANENT", $type);
-            }
             foreach my $line (@{ $action->{lines} // [] }) {
-                Devel::Probe::add_probe($file, $line, $type);
+                add_probe($file, $line, $type);
             }
             next;
         }
     }
+}
+
+sub add_probe {
+    my ($file, $line, $type) = @_;
+    if ($type ne ONCE && $type ne PERMANENT) {
+        croak sprintf("'%s' is not a valid probe type: try Devel::Probe::ONCE|PERMANENT", $type);
+    }
+    my $probes = Devel::Probe::_internal_probe_state();
+    $probes->{$file}->{$line} = $type;
 }
 
 sub dump {


### PR DESCRIPTION
(This PR is built on top of #9, so let's decide on that one before doing anything with this)

This PR shifts `add_probe` to a Perl implementation, which removes the need to do tricky refcounting/hash traversal for clearing in XS: since the probe is fully populated from Perl, Perl handles all of the refcounting appropriately. As a result, the failing memleak test (on `add_probe`) passes in this branch.