### PR TITLE
custom probe argument

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -20,6 +20,7 @@ WriteMakefile(
     ],
     INC            => '-I.',
     OBJECT         => '$(O_FILES)',
+    CCFLAGS        => ' -std=c89',
     META_MERGE     => {
         'meta-spec' => { version => 2 },
         resources   => {
@@ -51,5 +52,6 @@ sub cflags {
     foreach (@cflags) {
         $_ = "CCFLAGS = $self->{CCFLAGS}" if /^CCFLAGS/;
     }
+
     return $self->{CFLAGS} = join("\n", @cflags) . "\n";
 }

--- a/lib/Devel/Probe.pm
+++ b/lib/Devel/Probe.pm
@@ -44,8 +44,9 @@ sub config {
             next unless $file;
 
             my $type = $action->{type} // ONCE;
+            my $args = $action->{args};
             foreach my $line (@{ $action->{lines} // [] }) {
-                add_probe($file, $line, $type);
+                add_probe($file, $line, $type, $args);
             }
             next;
         }
@@ -53,12 +54,13 @@ sub config {
 }
 
 sub add_probe {
-    my ($file, $line, $type) = @_;
+    my ($file, $line, $type, $args) = @_;
     if ($type ne ONCE && $type ne PERMANENT) {
         croak sprintf("'%s' is not a valid probe type: try Devel::Probe::ONCE|PERMANENT", $type);
     }
+
     my $probes = Devel::Probe::_internal_probe_state();
-    $probes->{$file}->{$line} = $type;
+    $probes->{$file}->{$line} = [$type, defined $args ? $args : ()];
 }
 
 sub dump {

--- a/probe.xs
+++ b/probe.xs
@@ -112,26 +112,23 @@ static AV* probe_settings(const char* file, int line)
     AV* settings = 0;
 
     rlines = hv_fetch(probe_hash, file, klen, 0);
-    if (rlines) {
-        lines = (HV*) SvRV(*rlines);
-    } else {
+    if (!rlines) {
         return 0;
     }
+    lines = (HV*) SvRV(*rlines);
 
     klen = sprintf(kstr, "%d", line);
     rsettings = hv_fetch(lines, kstr, klen, 0);
-    if (rsettings) {
-        if (!SvROK(*rsettings) || SvTYPE(SvRV(*rsettings)) != SVt_PVAV) {
-            croak("Devel::Probe settings must be an ARRAY ref");
-        }
-
-        settings = (AV*) SvRV(*rsettings);
-        return settings;
-    } else {
+    if (!rsettings) {
         return 0;
     }
 
-    return 0;
+    if (!SvROK(*rsettings) || SvTYPE(SvRV(*rsettings)) != SVt_PVAV) {
+        croak("Devel::Probe settings must be an ARRAY ref");
+    }
+
+    settings = (AV*) SvRV(*rsettings);
+    return settings;
 }
 
 /*

--- a/probe.xs
+++ b/probe.xs
@@ -44,7 +44,7 @@ void dbg_printf(const char *fmt, ...)
     va_end(args);
 }
 
-static inline void probe_invoke_callback(const char* file, int line, SV* user_arg, SV* callback)
+static void probe_invoke_callback(const char* file, int line, SV* user_arg, SV* callback)
 {
     int count;
 

--- a/t/006-dump.t
+++ b/t/006-dump.t
@@ -9,21 +9,26 @@ my $config = {
     actions => [
         { action => 'define', file => "foo", lines => [qw(4 5 6)] },
         { action => 'define', file => "bar", lines => [qw(7 8 9)], type => Devel::Probe::PERMANENT },
+        { action => 'define', file => "baz", lines => [10], args => { frobnicate => 'doubletime' }},
     ],
 };
 Devel::Probe::config($config);
 is_deeply(Devel::Probe::dump(), 
     { 
         foo => {
-            4 => Devel::Probe::ONCE,
-            5 => Devel::Probe::ONCE,
-            6 => Devel::Probe::ONCE,
+            4 => [Devel::Probe::ONCE],
+            5 => [Devel::Probe::ONCE],
+            6 => [Devel::Probe::ONCE],
         },
         bar => {
-            7 => Devel::Probe::PERMANENT,
-            8 => Devel::Probe::PERMANENT,
-            9 => Devel::Probe::PERMANENT,
+            7 => [Devel::Probe::PERMANENT],
+            8 => [Devel::Probe::PERMANENT],
+            9 => [Devel::Probe::PERMANENT],
         },
+        baz => {
+            10 => [Devel::Probe::ONCE, {frobnicate => "doubletime"}],
+        },
+
     },
 "dump returned a hash representing the probes in the correct state");
 

--- a/t/009-memleak.t
+++ b/t/009-memleak.t
@@ -4,7 +4,8 @@ use Test::More;
 use Devel::Probe;
 use Devel::Leak;
 
-my @probe = (__FILE__, 40, Devel::Probe::ONCE);
+my $impossible_probe_line = 999;
+my @probe = (__FILE__, $impossible_probe_line, Devel::Probe::ONCE);
 sub probe_cb { }
 
 leak_test(sub {
@@ -30,9 +31,39 @@ leak_test(sub {
 
 leak_test(sub {
         Devel::Probe::install();
+        Devel::Probe::add_probe(__FILE__, $impossible_probe_line, Devel::Probe::ONCE, ["foo"]);
+        Devel::Probe::remove();
+    }, 10000,  "no memory leak in install/add_probe + arg/remove cycle"
+);
+
+leak_test(sub {
+        Devel::Probe::install();
         Devel::Probe::trigger(\&probe_cb);
         Devel::Probe::remove();
     }, 10000, "no memory leak in install/trigger/remove cycle"
+);
+
+leak_test(sub {
+        Devel::Probe::install();
+        Devel::Probe::enable();
+        # this is a real probe line; we want to fire the probe a lot
+        Devel::Probe::add_probe(__FILE__, 60, Devel::Probe::PERMANENT, ["foo"]);
+        my $trigger_target = 1000;
+        my $trigger_count = 0;
+        Devel::Probe::trigger(sub {
+            my ($line, $file, $arg) = @_;
+            $trigger_count++;
+        });
+        my $foo = 0;
+        for (1 .. $trigger_target) {
+            my $bar = $_ + 1;
+            $foo += $bar; # probe fires here
+        }
+        if ($trigger_count != $trigger_target) {
+            die "probe did not fire correct number of times. can't use Test::More methods here because they break the memory leak detection";
+        }
+        Devel::Probe::remove();
+    }, 1000,  "no memory leak in install/add_probe + arg/frequent trigger/remove cycle"
 );
 
 sub leak_test {

--- a/t/010-probe-with-args.t
+++ b/t/010-probe-with-args.t
@@ -1,0 +1,39 @@
+use strict;
+use warnings;
+use Test::More;
+use Devel::Probe;
+my $file = __FILE__;
+my $expected = {
+    $file => {
+        29 => "foo",
+        30 => { blorg => "bar"},
+        31 => ["baz"],
+    }
+};
+
+my $triggered;
+Devel::Probe::trigger(sub {
+    my ($file, $line, $args) = @_;
+    $triggered->{$file}->{$line} = $args;
+});
+
+my $actions = [
+    { action => "enable" },
+    map {
+        { action => "define", file => $file, lines => [$_], args => $expected->{$file}->{$_} }
+    } sort keys %{ $expected->{$file} }
+];
+
+Devel::Probe::config({actions => $actions});
+
+my $x = 1; # probe 1
+my $y = 2; # probe 2
+my $z = $y * 42; # probe 3
+
+is_deeply(
+    $triggered,
+    $expected,
+    "probes fired with correct arguments"
+);
+
+done_testing;


### PR DESCRIPTION
(This PR builds on #10, so let's decide on that before discussing this one)

This introduces custom args to probe callbacks by changing the probe_hash data structure from this:

```perl
{
    "foo.pl" => {
        10 => 1,
        15 => 2,
    }
}
```

To this:
```perl
{
    "foo.pl" => {
        10 => [1, { user => 'btyler', vars => [ '$user_id', '$log_level' ] },
        15 => [2, "halt-and-catch-fire" ],
    }
}
```
The first index in the AV is the probe type, the second is the user's argument (if any).