### PR TITLE
WIP: Support simple cases of string eval

### DIFF
--- a/t/011-string-eval.t
+++ b/t/011-string-eval.t
@@ -1,0 +1,55 @@
+use strict;
+use warnings;
+use Test::More;
+use Devel::Probe;
+my $file = __FILE__;
+my $expected = {
+    $file => {
+        29 => 1,
+        36 => 1,
+    }
+};
+
+my $triggered;
+Devel::Probe::trigger(sub {
+    my ($file, $line) = @_;
+    $triggered->{$file}->{$line} = 1;
+});
+
+my $actions = [
+    { action => "enable" },
+    map {
+        { action => "define", file => $file, lines => [$_] }
+    } sort keys %{ $expected->{$file} }
+];
+
+Devel::Probe::config({actions => $actions});
+
+eval '
+    my $single_nested = 1; # probe 1
+';
+
+eval '
+    eval q!
+        eval q|
+            eval q(
+                my $deeply_nested = 1; # probe 2
+            );
+        |;
+    !;
+';
+
+
+# This test matters because entering a string eval resets the value of __FILE__
+# to '(eval 1234)', where 1234 is an internal perl ID, and the value of
+# __LINE__ to be relative to the start of the string being eval'd. These are
+# not names that a user can reasonably set a probe on, so Devel::Probe skips
+# over string eval frames and adds their line numbers to the 'real' line offset
+# to create sensible names.
+is_deeply(
+    $triggered,
+    $expected,
+    "probes fired inside string eval using human-readable file/line names"
+);
+
+done_testing;


### PR DESCRIPTION
The value of `CopFILE` inside a string `eval` isn't the filename you edit with an editor, but something like `(eval 1234)`. Furthermore, the line number is relative to the start of the `eval` string. That's tricky to set a probe on, so this PR skips over those string `eval` frames and computes line numbers based on the offset in the file when the `eval` began.

This PR is a bit of a WIP because it's only a partial solution.

Nested `eval` works fine:
```perl
    eval '
        eval q|
            eval q^
                my $foo = "bar";
                my $bar = "baz";
            ^;
        |;
    ';
```
You can set a probe on the `$bar` line using the regular filename/line number.

But a sub declared & invoked inside an `eval` does not work:
```perl
    eval '
        sub my_cool_sub {
            my $foo = "bar";
            my $bar = "baz";
        }
        my_cool_sub();
    ';
```
TRACE logging will still show `(eval 1234)` as the filename, and incorrect line offsets. This is because the `caller_cx` for the `$bar` line is a sub, so the check implemented here decides all is well and quits searching the stack.

Not sure yet how to fix this; I suspect the answer might be to hook `OP_entereval` and save line/file there... or something.