### PR TITLE
Makefile.PL: overriding CCFLAGS drops important flags

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -21,7 +21,6 @@ WriteMakefile(
     ],
     INC            => '-I.',
     OBJECT         => '$(O_FILES)',
-    CCFLAGS        => ' -std=c89',
     META_MERGE     => {
         'meta-spec' => { version => 2 },
         resources   => {


### PR DESCRIPTION
...like -D_FILE_OFFSET_BITS, which breaks compilation in alpine